### PR TITLE
Add Windows executable build support and GUI improvements

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,85 @@
+name: Build Windows Executable
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  release:
+    types: [published]
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    
+    - name: Build Windows executable
+      run: |
+        pyinstaller --onefile --windowed --name="PAS Wireless Device Exporter" --icon=icon.ico main.py
+    
+    - name: Upload Windows executable
+      uses: actions/upload-artifact@v3
+      with:
+        name: pas-wireless-device-exporter-windows
+        path: "dist/PAS Wireless Device Exporter.exe"
+    
+    - name: Release
+      if: github.event_name == 'release'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: "dist/PAS Wireless Device Exporter.exe"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-multi-platform:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.11']
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    
+    - name: Build executable (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        pyinstaller --onefile --windowed --name="PAS Wireless Device Exporter - Windows" main.py
+    
+    - name: Build executable (macOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        pyinstaller --onefile --windowed --name="PAS Wireless Device Exporter - macOS" main.py
+    
+    - name: Build executable (Linux)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        pyinstaller --onefile --name="PAS Wireless Device Exporter - Linux" main.py
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: modbus-exporter-${{ matrix.os }}
+        path: dist/

--- a/README.md
+++ b/README.md
@@ -1,22 +1,114 @@
-# PAS Wireless Devices Exporter
+# Modbus Data Exporter
 
-Ein plattformübergreifendes Tool zum Auslesen von Wireless Devices via ModbusTCP vom Schneider Electric PanelServer.
+A GUI application for exporting Modbus device data to CSV and Excel formats.
 
-## Funktionen
+## Features
 
-- Abfrage der DeviceIDs vom PanelServer (Unit ID 255)
-- Abfrage von: Seriennummer, RF-ID, Product Model und Device Name
-- CSV-Export
+- Connect to Modbus TCP devices
+- Export device data to CSV and Excel formats
+- Real-time connection testing
+- Cross-platform support (Windows, macOS, Linux)
 
-## Nutzung
+## Requirements
 
-1. IP-Adresse des PanelServers eingeben
-2. „Abfragen & Exportieren“ klicken
-3. CSV-Datei speichern
+- Python 3.11 or higher
+- See `requirements.txt` for Python dependencies
 
-## Build-Status
+## Installation
 
-| Plattform       | Build         |
-|----------------|---------------|
-| Windows (.exe) | ✅            |
-| macOS (.app)   | ✅ (unsigniert) |
+1. Clone the repository
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Usage
+
+### Running the Application
+
+```bash
+python main.py
+```
+
+### Building Windows Executable
+
+#### Using GitHub Actions (Recommended)
+
+1. Push your code to GitHub
+2. The GitHub Actions workflow will automatically build executables for Windows, macOS, and Linux
+3. Download the artifacts from the Actions tab
+
+#### Building Locally
+
+1. Install build dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Run the build script:
+   ```bash
+   python build_windows.py
+   ```
+
+3. Or use PyInstaller directly:
+   ```bash
+   pyinstaller --onefile --windowed --name="PAS Wireless Device Exporter" main.py
+   ```
+
+#### Using the Spec File
+
+For advanced configuration, use the spec file:
+
+```bash
+pyinstaller modbus_exporter.spec
+```
+
+## Dependencies for Windows Build
+
+The `requirements.txt` includes everything needed for Windows executable building:
+
+- **pyinstaller**: Creates standalone executables
+- **auto-py-to-exe**: GUI tool for PyInstaller (optional)
+- **pywin32**: Windows-specific functionality
+- **pymodbus**: Modbus protocol implementation
+- **openpyxl**: Excel file support
+
+## GitHub Actions Workflow
+
+The `.github/workflows/build-windows.yml` file provides:
+
+- Automatic building on push/PR
+- Multi-platform support (Windows, macOS, Linux)
+- Artifact upload
+- Automatic release creation
+
+## File Structure
+
+```
+├── main.py                 # Main application
+├── requirements.txt        # Python dependencies
+├── modbus_exporter.spec   # PyInstaller configuration
+├── build_windows.py       # Local build script
+├── .github/
+│   └── workflows/
+│       └── build-windows.yml  # GitHub Actions workflow
+└── README.md              # This file
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Missing tkinter**: On some Linux systems, install `python3-tk`
+2. **PyInstaller issues**: Try using the spec file for better control
+3. **Modbus connection**: Ensure the device IP and port are correct
+
+### Build Issues
+
+1. **Windows**: Ensure Visual C++ Build Tools are installed
+2. **Icon missing**: Remove `--icon=icon.ico` from build commands if no icon file
+3. **Large executable**: Use `--exclude-module` to remove unused modules
+
+## License
+
+MIT License

--- a/build_windows.py
+++ b/build_windows.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Build script for creating Windows executable
+Run this script to build the Windows executable locally
+"""
+
+import os
+import sys
+import subprocess
+import shutil
+
+def run_command(cmd):
+    """Run a command and return the result"""
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error: {result.stderr}")
+        return False
+    print(f"Output: {result.stdout}")
+    return True
+
+def build_executable():
+    """Build the Windows executable"""
+    print("Building Windows executable...")
+    
+    # Clean previous builds
+    if os.path.exists('dist'):
+        shutil.rmtree('dist')
+    if os.path.exists('build'):
+        shutil.rmtree('build')
+    
+    # Install dependencies
+    print("Installing dependencies...")
+    if not run_command([sys.executable, '-m', 'pip', 'install', '-r', 'requirements.txt']):
+        return False
+    
+    # Build using PyInstaller
+    print("Building with PyInstaller...")
+    cmd = [
+        'pyinstaller',
+        '--onefile',
+        '--windowed',
+        '--name=PAS Wireless Device Exporter',
+        '--add-data=main.py;.',
+        '--hidden-import=pymodbus',
+        '--hidden-import=pymodbus.client',
+        '--hidden-import=openpyxl',
+        '--hidden-import=tkinter',
+        '--hidden-import=tkinter.filedialog',
+        '--hidden-import=tkinter.messagebox',
+        'main.py'
+    ]
+    
+    # Add icon if it exists
+    if os.path.exists('icon.ico'):
+        cmd.extend(['--icon=icon.ico'])
+    
+    if not run_command(cmd):
+        return False
+    
+    print("Build completed successfully!")
+    print(f"Executable created: {os.path.abspath('dist/PAS Wireless Device Exporter.exe')}")
+    return True
+
+if __name__ == "__main__":
+    if build_executable():
+        print("Build successful!")
+    else:
+        print("Build failed!")
+        sys.exit(1)


### PR DESCRIPTION
- Add comprehensive Windows build support with GitHub Actions
- Update executable name to 'PAS Wireless Device Exporter.exe'
- Add PyInstaller configuration with .spec file
- Include local build script for development
- Update GUI layout and styling:
  - Move Test IP button to separate frame between IP and Export sections
  - Make Test IP button full width matching other frames
  - Increase window height to 700px for better log visibility
  - Update Exit button to match Start/Stop button styling
- Add comprehensive requirements.txt for Windows builds
- Include multi-platform build support (Windows, macOS, Linux)
- Update documentation with build instructions